### PR TITLE
feat(user): adds a force TOTP option per user

### DIFF
--- a/e2e/account.spec.ts
+++ b/e2e/account.spec.ts
@@ -200,6 +200,104 @@ test.describe('account', () => {
 				})
 			})
 		})
+
+		test.describe('user.forceTotp is true', () => {
+			let page: Page
+			let teardown: VoidFunction
+			let baseURL: string
+
+			test.beforeAll(async ({ setup, browser, helpers }) => {
+				const setupResult = await setup({ forceSetup: true })
+				teardown = setupResult.teardown
+				baseURL = setupResult.baseURL
+				page = await browser.newPage()
+
+				await helpers.createFirstUser({ page, baseURL, forceTotp: true })
+				await page.waitForURL(/^(.*?)\/admin\/setup-totp(\?back=.*?)?$/g)
+				await helpers.setupTotp({ page, baseURL })
+				await page.goto(`${baseURL}/admin/account`)
+			})
+
+			test.afterAll(async () => {
+				await teardown()
+				await page.close()
+			})
+
+			test('setup button should not be visible', async () => {
+				await expect(page.getByRole('link', { name: 'Setup' })).not.toBeVisible()
+			})
+
+			test('remove button should not be visible', async () => {
+				await expect(page.getByRole('button', { name: 'Remove' })).not.toBeVisible()
+			})
+
+			test('should have Configured span', async () => {
+				const span = page.getByText('Configured')
+				const root = page.locator('css=#totp-ui-field')
+				await expect(span).toBeVisible()
+				await expect(root.filter({ has: span })).toHaveCount(1)
+			})
+
+			test.describe('GET /api/account/me', () => {
+				test.describe.configure({ mode: 'serial' })
+
+				let res
+				let data
+
+				test.beforeAll(async () => {
+					res = await page.request.get(`${baseURL}/api/users/me`)
+
+					if (res.ok()) {
+						data = await res.json()
+					}
+				})
+
+				test('response should be ok', async () => {
+					await expect(res.ok()).toBeTruthy()
+				})
+
+				test('user should be logged in with totp strategy', async () => {
+					await expect(data.user).toBeTruthy()
+					await expect(data.strategy).toBe('totp')
+				})
+
+				test('should not include totpSecret', async () => {
+					await expect(data.user.totpSecret).toBeUndefined()
+				})
+			})
+
+			test.describe('GraphQL meUser', () => {
+				test.describe.configure({ mode: 'serial' })
+
+				let res
+				let data
+
+				test.beforeAll(async () => {
+					res = await page.request.post(`${baseURL}/api/graphql`, {
+						data: {
+							query: `query { meUser { user { email, totpSecret }, strategy }}`,
+						},
+					})
+
+					if (res.ok()) {
+						data = await res.json()
+					}
+				})
+
+				test('response should be ok', async () => {
+					await expect(res.ok()).toBeTruthy()
+				})
+
+				test('user should be logged in with totp strategy', async () => {
+					await expect(data.data.meUser.user).toBeTruthy()
+					await expect(data.data.meUser.strategy).toBe('totp')
+				})
+
+				test('should not include totpSecret', async () => {
+					await expect(data.data.meUser.user.totpSecret).toBeNull()
+				})
+			})
+		})
 	})
 
 	test.describe("user doesn't have TOTP configured", () => {
@@ -328,6 +426,91 @@ test.describe('account', () => {
 				const root = page.locator('css=#totp-ui-field')
 				await expect(span).not.toBeVisible()
 				await expect(root.filter({ has: span })).toHaveCount(0)
+			})
+
+			test.describe('GET /api/account/me', () => {
+				test.describe.configure({ mode: 'serial' })
+
+				let res
+				let data
+
+				test.beforeAll(async () => {
+					res = await page.request.get(`${baseURL}/api/users/me`)
+
+					if (res.ok()) {
+						data = await res.json()
+					}
+				})
+
+				test('response should be ok', async () => {
+					await expect(res.ok()).toBeTruthy()
+				})
+
+				test('user should be logged in with default strategy', async () => {
+					await expect(data.user).toBeTruthy()
+					await expect(data.strategy).not.toBe('totp')
+				})
+
+				test('should not include totpSecret', async () => {
+					await expect(data.user.totpSecret).toBeUndefined()
+				})
+			})
+
+			test.describe('GraphQL meUser', () => {
+				test.describe.configure({ mode: 'serial' })
+
+				let res
+				let data
+
+				test.beforeAll(async () => {
+					res = await page.request.post(`${baseURL}/api/graphql`, {
+						data: {
+							query: `query { meUser { user { email, totpSecret }, strategy }}`,
+						},
+					})
+
+					if (res.ok()) {
+						data = await res.json()
+					}
+				})
+
+				test('response should be ok', async () => {
+					await expect(res.ok()).toBeTruthy()
+				})
+
+				test('user should be logged in with default strategy', async () => {
+					await expect(data.data.meUser.user).toBeTruthy()
+					await expect(data.data.meUser.strategy).not.toBe('totp')
+				})
+
+				test('should not include totpSecret', async () => {
+					await expect(data.data.meUser.user.totpSecret).toBeNull()
+				})
+			})
+		})
+
+		test.describe('user.forceTotp is true', () => {
+			let page: Page
+			let baseURL: string
+			let teardown: VoidFunction
+
+			test.beforeAll(async ({ setup, browser, helpers }) => {
+				const setupResult = await setup({ forceSetup: false })
+				teardown = setupResult.teardown
+				baseURL = setupResult.baseURL
+				page = await browser.newPage()
+				await helpers.createFirstUser({ page, baseURL, forceTotp: true })
+				await page.waitForURL(/^(.*?)\/admin\/setup-totp(\?back=.*?)?$/g)
+			})
+
+			test.afterAll(async () => {
+				await teardown()
+				await page.close()
+			})
+
+			test('should redirect to setup page', async ({}) => {
+				await page.goto(`${baseURL}/admin/account`)
+				await expect(page).toHaveURL(/^(.*?)\/admin\/setup-totp(\?back=.*?)?$/g)
 			})
 
 			test.describe('GET /api/account/me', () => {

--- a/e2e/helpers/create-first-user.ts
+++ b/e2e/helpers/create-first-user.ts
@@ -4,13 +4,15 @@ type Args = {
 	page: Page
 	baseURL: string
 	adminRoute?: string
+	forceTotp?: boolean
 }
 
-export async function createFirstUser({ page, baseURL, adminRoute = '/admin' }: Args) {
+export async function createFirstUser({ page, baseURL, adminRoute = '/admin', forceTotp }: Args) {
 	await page.goto(`${baseURL}${adminRoute}/create-first-user`)
 	await page.getByLabel('Email').pressSequentially('human@domain.com')
 	await page.getByLabel('New Password').pressSequentially('123456')
 	await page.getByLabel('Confirm Password').pressSequentially('123456')
+	if (forceTotp) await page.getByLabel('Force TOTP').check()
 
 	await page.getByRole('button', { name: 'Create' }).click({ delay: 1000 })
 }

--- a/src/api/remove.ts
+++ b/src/api/remove.ts
@@ -21,7 +21,7 @@ export function removeEndpointHandler(pluginOptions: PayloadTOTPConfig) {
 			return Response.json({ message: i18n.t('error:unauthorized'), ok: false })
 		}
 
-		if (!user.hasTotp || pluginOptions.forceSetup) {
+		if (!user.hasTotp || user.forceTotp || pluginOptions.forceSetup) {
 			return Response.json({ message: i18n.t('error:unauthorized'), ok: false })
 		}
 

--- a/src/components/Field/index.tsx
+++ b/src/components/Field/index.tsx
@@ -23,6 +23,7 @@ export const TOTPField = (args: Args) => {
 	} = args
 
 	const user = _user as unknown as UserWithTotp
+	const forceTotp = !user?.forceTotp && !pluginOptions.forceSetup
 
 	if (!user || user.id !== id) {
 		return null
@@ -44,7 +45,7 @@ export const TOTPField = (args: Args) => {
 				<span className={styles.description}>{i18n.t('totpPlugin:fieldDescription')}</span>
 			</div>
 			<div className={styles.action}>
-				{user.hasTotp && !pluginOptions.forceSetup && (
+				{user.hasTotp && forceTotp && (
 					<Remove
 						i18n={i18n}
 						payload={payload}
@@ -52,7 +53,7 @@ export const TOTPField = (args: Args) => {
 						user={user}
 					/>
 				)}
-				{!user.hasTotp && !pluginOptions.forceSetup && (
+				{!user.hasTotp && forceTotp && (
 					<Setup backUrl={url} i18n={i18n} payload={payload} />
 				)}
 			</div>

--- a/src/components/Provider/index.client.tsx
+++ b/src/components/Provider/index.client.tsx
@@ -30,7 +30,13 @@ export default function TOTPProviderClient(args: Args) {
 			pathname !== verifyUrl
 		) {
 			router.push(`${verifyUrl}?back=${encodeURIComponent(pathname)}`)
-		} else if (user && !user.hasTotp && forceSetup && pathname !== setupUrl && user._strategy !== 'api-key') {
+		} else if (
+			user &&
+			!user.hasTotp &&
+			(user.forceTotp || forceSetup) &&
+			pathname !== setupUrl &&
+			user._strategy !== 'api-key'
+		) {
 			router.push(`${setupUrl}?back=${encodeURIComponent(pathname)}`)
 		}
 		// eslint-disable-next-line react-hooks/exhaustive-deps

--- a/src/components/Provider/index.tsx
+++ b/src/components/Provider/index.tsx
@@ -31,9 +31,20 @@ export const TOTPProvider = async (args: Args) => {
 		serverURL: payload.config.serverURL,
 	})
 
-	if (user && user.hasTotp && !['api-key', 'totp'].includes(user._strategy) && pathname !== verifyUrl) {
+	if (
+		user &&
+		user.hasTotp &&
+		!['api-key', 'totp'].includes(user._strategy) &&
+		pathname !== verifyUrl
+	) {
 		redirect(`${verifyUrl}?back=${encodeURIComponent(pathname)}`)
-	} else if (user && !user.hasTotp && pluginOptions.forceSetup && pathname !== setupUrl && user._strategy !== 'api-key') {
+	} else if (
+		user &&
+		!user.hasTotp &&
+		(user.forceTotp || pluginOptions.forceSetup) &&
+		pathname !== setupUrl &&
+		user._strategy !== 'api-key'
+	) {
 		redirect(`${setupUrl}?back=${encodeURIComponent(pathname)}`)
 	} else {
 		return (

--- a/src/index.ts
+++ b/src/index.ts
@@ -185,6 +185,11 @@ const payloadTotp =
 									},
 									virtual: true,
 								} as CheckboxField,
+								{
+									name: 'forceTotp',
+									type: 'checkbox',
+									label: 'Force TOTP',
+								} as CheckboxField,
 							],
 							hooks: {
 								...(collection.hooks || {}),

--- a/src/totpAccess.ts
+++ b/src/totpAccess.ts
@@ -26,7 +26,7 @@ export const totpAccess: (innerAccess?: Access) => Access = (innerAccess) => {
 		}
 
 		if (
-			(pluginOptions.forceSetup && user._strategy === 'totp') ||
+			((user.forceTotp || pluginOptions.forceSetup) && user._strategy === 'totp') ||
 			user._strategy === 'api-key'
 		) {
 			return innerAccess ? innerAccess(args) : true

--- a/src/types.ts
+++ b/src/types.ts
@@ -10,5 +10,6 @@ export type PayloadTOTPConfig = {
 }
 
 export type UserWithTotp = {
+	forceTotp: boolean
 	hasTotp: boolean
 } & User


### PR DESCRIPTION
This allows for architectures where forcing all users of the collection to have 2fa enabled is not practical. This may be where both admins and frontend users are stored in the same collection, but only admin users require 2fa.